### PR TITLE
feat: add ATP v2 envelope compatibility to indexer parser

### DIFF
--- a/packages/indexer/src/poller/parser.test.ts
+++ b/packages/indexer/src/poller/parser.test.ts
@@ -34,6 +34,11 @@ describe('Parser', () => {
       expect(classifyMessageType(data)).toBe('OPENCLAW_ACTION');
     });
 
+    it('should classify message_type ATP envelopes', () => {
+      const data = { atp_version: '2.1', message_type: 'rental_completed' };
+      expect(classifyMessageType(data)).toBe('rental_completed');
+    });
+
     it('should classify agent_comms from structure', () => {
       const data = { from: 'agent1', text: 'hello', timestamp: '2026-01-01' };
       expect(classifyMessageType(data)).toBe('agent_comms');
@@ -90,6 +95,29 @@ describe('Parser', () => {
       expect(result).toBeTruthy();
     });
 
+    it('should validate a v2.1 rental_completed envelope by normalizing it', () => {
+      const data = {
+        atp_version: '2.1',
+        message_type: 'rental_completed',
+        agent_id: 'did:hedera:mainnet:test_0.0.123',
+        timestamp: '2026-03-10T15:00:00.123Z',
+        payload: {
+          rental_id: 'rental_abc123',
+          total_cost_usd: 12.5,
+          settlement: {
+            owner: 10,
+            creator: 1,
+            network: 1,
+            treasury: 0.5,
+          },
+        },
+      };
+      const result = validateMessage(data);
+      expect(result).toBeTruthy();
+      expect(result?.type).toBe('rental_completed');
+      expect((result as any)?.rentalId).toBe('rental_abc123');
+    });
+
     it('should return null for invalid message', () => {
       const data = { invalid: 'message' };
       const result = validateMessage(data);
@@ -123,6 +151,38 @@ describe('Parser', () => {
       expect(result.messageType).toBe('AGENT_INITIALIZATION');
       expect(result.validated).toBeTruthy();
       expect(result.error).toBeUndefined();
+    });
+
+    it('should parse a current ATP envelope and return normalized validated output', () => {
+      const messageData = {
+        atp_version: '2.1',
+        message_type: 'rental_initiated',
+        agent_id: 'did:hedera:mainnet:test_0.0.123',
+        timestamp: '2026-03-10T15:00:00.123Z',
+        payload: {
+          rental_id: 'rental_abc123',
+          renter: '0.0.333333',
+          stake_usd: 50,
+          usage_buffer_usd: 100,
+          escrow_account: '0.0.888888',
+        },
+      };
+      const base64 = Buffer.from(JSON.stringify(messageData)).toString('base64');
+      const mirrorMessage: MirrorNodeMessage = {
+        consensus_timestamp: '1234567890.000000000',
+        topic_id: '0.0.123',
+        message: base64,
+        payer_account_id: '0.0.456',
+        sequence_number: 1,
+        running_hash: 'hash',
+        running_hash_version: 3,
+      };
+
+      const result = parseMessage(mirrorMessage);
+      expect(result.messageType).toBe('rental_initiated');
+      expect(result.validated).toBeTruthy();
+      expect((result.validated as any)?.type).toBe('rental_initiated');
+      expect((result.validated as any)?.rentalId).toBe('rental_abc123');
     });
 
     it('should handle invalid base64', () => {

--- a/packages/indexer/src/poller/parser.ts
+++ b/packages/indexer/src/poller/parser.ts
@@ -28,6 +28,99 @@ export function decodeBase64Message(base64: string): unknown {
   }
 }
 
+function toEpochTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return Date.now();
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+}
+
+function normalizeATPEnvelope(data: unknown): unknown {
+  if (!data || typeof data !== 'object') {
+    return data;
+  }
+
+  const obj = data as Record<string, unknown>;
+  const messageType = typeof obj.message_type === 'string' ? obj.message_type : null;
+  const atpVersion = typeof obj.atp_version === 'string' ? obj.atp_version : null;
+  const agentId = typeof obj.agent_id === 'string' ? obj.agent_id : undefined;
+  const payload = (obj.payload ?? obj.data) as Record<string, unknown> | undefined;
+
+  if (!messageType || !atpVersion || !payload) {
+    return data;
+  }
+
+  const timestamp = toEpochTimestamp(obj.timestamp);
+
+  if (messageType === 'agent_created') {
+    return {
+      version: atpVersion,
+      type: 'agent_created',
+      agentId: agentId ?? '',
+      agentName: typeof payload.name === 'string' ? payload.name : (agentId ?? 'unknown-agent'),
+      platform: typeof payload.platform === 'string' ? payload.platform : 'ATP',
+      timestamp,
+      metadata: payload,
+    };
+  }
+
+  if (messageType === 'rental_initiated') {
+    return {
+      version: atpVersion,
+      type: 'rental_initiated',
+      agentId: agentId ?? '',
+      rentalId: typeof payload.rental_id === 'string' ? payload.rental_id : '',
+      renter: typeof payload.renter === 'string' ? payload.renter : '',
+      escrowAccount: typeof payload.escrow_account === 'string' ? payload.escrow_account : '',
+      stakeUsd: toNumber(payload.stake_usd),
+      bufferUsd: toNumber(payload.usage_buffer_usd ?? payload.buffer_usd),
+      timestamp,
+    };
+  }
+
+  if (messageType === 'rental_completed') {
+    const settlement = (payload.settlement ?? {}) as Record<string, unknown>;
+    return {
+      version: atpVersion,
+      type: 'rental_completed',
+      rentalId: typeof payload.rental_id === 'string' ? payload.rental_id : '',
+      totalCostUsd: toNumber(payload.total_cost_usd ?? payload.total_cost),
+      settlement: {
+        owner: toNumber(settlement.owner),
+        creator: toNumber(settlement.creator),
+        network: toNumber(settlement.network),
+        treasury: toNumber(settlement.treasury),
+      },
+      timestamp,
+    };
+  }
+
+  return data;
+}
+
 export function classifyMessageType(data: unknown): string | null {
   if (!data || typeof data !== 'object') {
     return null;
@@ -35,8 +128,12 @@ export function classifyMessageType(data: unknown): string | null {
 
   const obj = data as Record<string, unknown>;
 
-  if ('type' in obj) {
-    return obj.type as string;
+  if (typeof obj.type === 'string') {
+    return obj.type;
+  }
+
+  if (typeof obj.message_type === 'string') {
+    return obj.message_type;
   }
 
   if ('from' in obj && 'text' in obj && 'timestamp' in obj) {
@@ -47,8 +144,10 @@ export function classifyMessageType(data: unknown): string | null {
 }
 
 export function validateMessage(data: unknown): HCSMessage | null {
+  const normalized = normalizeATPEnvelope(data);
+
   try {
-    return hcsMessageSchema.parse(data);
+    return hcsMessageSchema.parse(normalized);
   } catch {
     const schemas = [
       agentInitializationSchema,
@@ -62,7 +161,7 @@ export function validateMessage(data: unknown): HCSMessage | null {
 
     for (const schema of schemas) {
       try {
-        return schema.parse(data) as HCSMessage;
+        return schema.parse(normalized) as HCSMessage;
       } catch {
         continue;
       }


### PR DESCRIPTION
## Summary
Add the minimum safe ATP v2/v2.1 envelope compatibility pass to the restored indexer.

## Scope
- accept `message_type` as well as legacy `type`
- normalize ATP envelope fields before parser validation
- keep legacy flat-message support intact
- add focused parser tests

## Validation
- targeted parser tests pass
- build passes
- unrelated DB-backed route test failures remain separate